### PR TITLE
Coerce limit and skip to Numbers

### DIFF
--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -65,8 +65,8 @@ router.get('/', auth.optional, function(req, res, next) {
 
     return Promise.all([
       Article.find(query)
-        .limit(limit)
-        .skip(offset)
+        .limit(Number(limit))
+        .skip(Number(offset))
         .sort({createdAt: 'desc'})
         .populate('author')
         .exec(),
@@ -104,8 +104,8 @@ router.get('/feed', auth.required, function(req, res, next) {
 
     Promise.all([
       Article.find({ author: {$in: user.following}})
-        .limit(limit)
-        .skip(offset)
+        .limit(Number(limit))
+        .skip(Number(offset))
         .populate('author')
         .exec(),
       Article.count({ author: {$in: user.following}})


### PR DESCRIPTION
Because I was getting:

```
MongoError: Failed to parse: { find: "articles", filter: { author: ObjectId('589dccdd34b8937c7e444ee3') }, sort: { createdAt: -1 }, limit: "5" }. 'limit' field must be numeric.
    at Function.MongoError.create (/Users/kdodds/Desktop/node-express-realworld-example-app/node_modules/mongodb-core/lib/error.js:31:11)
    at queryCallback (/Users/kdodds/Desktop/node-express-realworld-example-app/node_modules/mongodb-core/lib/cursor.js:196:36)
    at Callbacks.emit (/Users/kdodds/Desktop/node-express-realworld-example-app/node_modules/mongodb-core/lib/topologies/server.js:116:3)
    at Connection.messageHandler (/Users/kdodds/Desktop/node-express-realworld-example-app/node_modules/mongodb-core/lib/topologies/server.js:291:23)
    at Socket.<anonymous> (/Users/kdodds/Desktop/node-express-realworld-example-app/node_modules/mongodb-core/lib/connection/connection.js:285:22)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:548:20)
GET /api/articles?author=kentcdodds&limit=5&offset=0 500 23.662 ms - 613
```

And this fixes it :)