### PR TITLE
Simplify token logic

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,8 +3,8 @@ var secret = require('../config').secret;
 
 function getTokenFromHeader(req){
   if (req.headers.authorization && 
-      req.headers.authorization.split(' ')[0] === 'Token' ||
-      req.headers.authorization.split(' ')[0] === 'Bearer') {
+       (req.headers.authorization.split(' ')[0] === 'Token' || 
+        req.headers.authorization.split(' ')[0] === 'Bearer')){
     return req.headers.authorization.split(' ')[1];
   }
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,8 +2,9 @@ var jwt = require('express-jwt');
 var secret = require('../config').secret;
 
 function getTokenFromHeader(req){
-  if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Token' ||
-      req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
+  if (req.headers.authorization && 
+      req.headers.authorization.split(' ')[0] === 'Token' ||
+      req.headers.authorization.split(' ')[0] === 'Bearer') {
     return req.headers.authorization.split(' ')[1];
   }
 


### PR DESCRIPTION
This should do the same thing as before, just removing the extra authorization object check.