### PR TITLE
Update auth.js

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -13,12 +13,14 @@ function getTokenFromHeader(req){
 var auth = {
   required: jwt({
     secret: secret,
+    algorithms: ['HS256'],
     userProperty: 'payload',
     getToken: getTokenFromHeader
   }),
   optional: jwt({
     secret: secret,
     userProperty: 'payload',
+    algorithms: ['HS256'],
     credentialsRequired: false,
     getToken: getTokenFromHeader
   })


### PR DESCRIPTION
Changes in express-jwt v6.0.0. 
'The algorithms parameter is required to prevent potential downgrade attacks when providing third party libraries as secrets.'