### PR TITLE
fix(auth): prevent race condition on user creation with DB-level uniqueness

### DIFF
--- a/src/app/routes/auth/auth.service.ts
+++ b/src/app/routes/auth/auth.service.ts
@@ -6,35 +6,6 @@ import { RegisteredUser } from './registered-user.model';
 import generateToken from './token.utils';
 import { User } from './user.model';
 
-const checkUserUniqueness = async (email: string, username: string) => {
-  const existingUserByEmail = await prisma.user.findUnique({
-    where: {
-      email,
-    },
-    select: {
-      id: true,
-    },
-  });
-
-  const existingUserByUsername = await prisma.user.findUnique({
-    where: {
-      username,
-    },
-    select: {
-      id: true,
-    },
-  });
-
-  if (existingUserByEmail || existingUserByUsername) {
-    throw new HttpException(422, {
-      errors: {
-        ...(existingUserByEmail ? { email: ['has already been taken'] } : {}),
-        ...(existingUserByUsername ? { username: ['has already been taken'] } : {}),
-      },
-    });
-  }
-};
-
 export const createUser = async (input: RegisterInput): Promise<RegisteredUser> => {
   const email = input.email?.trim();
   const username = input.username?.trim();
@@ -53,32 +24,43 @@ export const createUser = async (input: RegisterInput): Promise<RegisteredUser> 
     throw new HttpException(422, { errors: { password: ["can't be blank"] } });
   }
 
-  await checkUserUniqueness(email, username);
+  try {
+    const hashedPassword = await bcrypt.hash(password, 10);
 
-  const hashedPassword = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: {
+        username,
+        email,
+        password: hashedPassword,
+        ...(image ? { image } : {}),
+        ...(bio ? { bio } : {}),
+        ...(demo ? { demo } : {}),
+      },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        bio: true,
+        image: true,
+      },
+    });
 
-  const user = await prisma.user.create({
-    data: {
-      username,
-      email,
-      password: hashedPassword,
-      ...(image ? { image } : {}),
-      ...(bio ? { bio } : {}),
-      ...(demo ? { demo } : {}),
-    },
-    select: {
-      id: true,
-      email: true,
-      username: true,
-      bio: true,
-      image: true,
-    },
-  });
+    return {
+      ...user,
+      token: generateToken(user.id),
+    };
+  } catch (err: any) {
+    if (err.code === "P2002" && Array.isArray(err.meta?.target)) {
+      const errors: Record<string, string[]> = {};
 
-  return {
-    ...user,
-    token: generateToken(user.id),
-  };
+      for (const field of err.meta.target as string[]) {
+        errors[field] = ["has already been taken"];
+      }
+
+      throw new HttpException(422, { errors });
+    }
+    throw err;
+  }
 };
 
 export const login = async (userPayload: any) => {


### PR DESCRIPTION
### Description:

This PR fixes a race condition that could occur when two users tried to register simultaneously with the same email or username.

Previously, we manually checked for existing emails and usernames before creating a user using the `checkUserUniqueness` function, which allowed a brief window where concurrent requests could bypass these checks and attempt duplicates. Although the database’s unique constraints prevented actual duplicate records, the application did **not handle** the resulting errors properly because user creation was not wrapped in a try-catch block. This led to unhandled errors without clear validation feedback.

Now, we have removed the `checkUserUniqueness` function and rely on Prisma’s built-in unique constraints at the database level to enforce uniqueness atomically. The user creation logic is wrapped in a try-catch block that catches Prisma’s `P2002` error and returns clean, detailed validation messages when duplicates are attempted.

**Benefits:**

* Eliminates the race condition fully
* Reduces database queries from 3 to 1, improving performance
* Simplifies code by removing manual uniqueness checks