### PR TITLE
fix(auth): validate email format early in register, login & update-user endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
+        "email-validator": "^2.0.4",
         "express": "~4.18.1",
         "express-jwt": "^8.4.1",
         "jsonwebtoken": "^9.0.2",
@@ -5540,6 +5541,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.615.tgz",
       "integrity": "sha512-/bKPPcgZVUziECqDc+0HkT87+0zhaWSZHNXqF8FLd2lQcptpmUFwoCSWjCdOng9Gdq+afKArPdEg/0ZW461Eng==",
       "dev": true
+    },
+    "node_modules/email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+      "engines": {
+        "node": ">4.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
+    "email-validator": "^2.0.4",
     "express": "~4.18.1",
     "express-jwt": "^8.4.1",
     "jsonwebtoken": "^9.0.2",

--- a/src/app/routes/auth/auth.service.ts
+++ b/src/app/routes/auth/auth.service.ts
@@ -98,6 +98,10 @@ export const login = async (userPayload: any) => {
     throw new HttpException(422, { errors: { password: ["can't be blank"] } });
   }
 
+  if (!validate(email)) {
+    throw new HttpException(422, { errors: { email: ["is invalid"] } });
+  }
+
   const user = await prisma.user.findUnique({
     where: {
       email,

--- a/src/app/routes/auth/auth.service.ts
+++ b/src/app/routes/auth/auth.service.ts
@@ -159,8 +159,12 @@ export const getCurrentUser = async (id: number) => {
 
 export const updateUser = async (userPayload: any, id: number) => {
   const { email, username, password, image, bio } = userPayload;
-  let hashedPassword;
 
+  if (email && !validate(email)) {
+    throw new HttpException(422, { errors: { email: ["is invalid"] } });
+  }
+
+  let hashedPassword;
   if (password) {
     hashedPassword = await bcrypt.hash(password, 10);
   }

--- a/src/app/routes/auth/auth.service.ts
+++ b/src/app/routes/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import * as bcrypt from 'bcryptjs';
+import { validate } from 'email-validator';
 import { RegisterInput } from './register-input.model';
 import prisma from '../../../prisma/prisma-client';
 import HttpException from '../../models/http-exception.model';
@@ -51,6 +52,10 @@ export const createUser = async (input: RegisterInput): Promise<RegisteredUser> 
 
   if (!password) {
     throw new HttpException(422, { errors: { password: ["can't be blank"] } });
+  }
+
+  if (!validate(email)) {
+    throw new HttpException(422, { errors: { email: ["is invalid"] } });
   }
 
   await checkUserUniqueness(email, username);


### PR DESCRIPTION
## Description

Currently, all three authentication-related endpoints (`/api/users`, `/api/users/login`, and `/api/user`) accept any string for the `email` field and only check existence against the database. This fix adds early-format email validation to all three endpoints.

Since we already enforce a correct email format at registration, it’s redundant (and wasteful) to hit the database every time with an obviously malformed value. This change:

* Adds early-format validation to the three endpoints
* Short-circuits invalid requests with a 422 response before any DB lookup
* Improves performance by avoiding unnecessary database calls
* Standardizes error messaging for all auth routes

#### What’s Changed

1. **`/api/users` (register) endpoint**
   * Added email format check using `email-validator`
   * Returns `422 Unprocessable Entity` +
     ```json
     {
       "errors": {
         "email": ["is invalid"]
       }
     }
     ```
     if validation fails

2. **`/api/users/login` (login) endpoint**
   * Moved DB lookup logic *after* the new format validation
   * Early exit with `422 Unprocessable Entity` + same `errors` payload if email is malformed

3. **`/api/user` (update user) endpoint**
   * Added format check for any incoming `email` in the update payload
   * Early exit with `422 Unprocessable Entity` + same `errors` payload if malformed

4. **Dependency updates**
   * Installed `email-validator` via `npm install email-validator`
   * Updated `package.json` & `package-lock.json`

---

#### How to Test

* **Register**
  ```bash
  curl -X POST http://localhost:3000/api/users \
    -H "Content-Type: application/json" \
    -d '{"user": {"email": "bad-email", "username": "user", "password": "passwd"}}'
  # 422, {"errors":{"email":["is invalid"]}}

* **LogIn**
  ```bash
  curl -X POST http://localhost:3000/api/users/login \
    -H "Content-Type: application/json" \
    -d '{"user": {"email": "bad-email", "password": "passwd"}}'
  # 422, {"errors":{"email":["is invalid"]}}
  ```

* **Update User**
  ```bash
  curl -X PUT http://localhost:3000/api/user \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <YOUR_JWT_TOKEN>" \
    -d '{"user": {"email": "bad-email"}}'
  # 422, {"errors":{"email":["is invalid"]}}
  ```
