### PR TITLE
refactor(article): extract reusable article sorting builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4650,23 +4650,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz",
@@ -5249,24 +5232,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/create-jest": {

--- a/src/app/routes/article/article.service.ts
+++ b/src/app/routes/article/article.service.ts
@@ -5,6 +5,29 @@ import profileMapper from '../profile/profile.utils';
 import articleMapper from './article.mapper';
 import { Tag } from '../tag/tag.model';
 
+type SortField = 'createdAt' | 'updatedAt' | 'title';
+type SortOrder = 'asc' | 'desc';
+
+const allowedSortFields: SortField[] = ['createdAt', 'updatedAt', 'title'];
+const allowedSortOrders: SortOrder[] = ['asc', 'desc'];
+
+const buildArticleOrderBy = (query: any = {}) => {
+  const sort = typeof query?.sort === 'string' ? query.sort : 'createdAt';
+  const order = typeof query?.order === 'string' ? query.order : 'desc';
+
+  const safeSort: SortField = allowedSortFields.includes(sort as SortField)
+    ? (sort as SortField)
+    : 'createdAt';
+
+  const safeOrder: SortOrder = allowedSortOrders.includes(order as SortOrder)
+    ? (order as SortOrder)
+    : 'desc';
+
+  return {
+    [safeSort]: safeOrder,
+  };
+};
+
 const buildFindAllQuery = (query: any, id: number | undefined) => {
   const queries: any = [];
   const orAuthorQuery = [];
@@ -76,9 +99,7 @@ export const getArticles = async (query: any, id?: number) => {
 
   const articles = await prisma.article.findMany({
     where: { AND: andQueries },
-    orderBy: {
-      createdAt: 'desc',
-    },
+    orderBy: buildArticleOrderBy(query),
     skip: Number(query.offset) || 0,
     take: Number(query.limit) || 10,
     include: {

--- a/src/tests/services/article.service.test.ts
+++ b/src/tests/services/article.service.test.ts
@@ -2,10 +2,51 @@ import prismaMock from '../prisma-mock';
 import {
   deleteComment,
   favoriteArticle,
+  getArticles,
   unfavoriteArticle,
 } from '../../app/routes/article/article.service';
 
 describe('ArticleService', () => {
+
+  describe('getArticles sorting', () => {
+    test('should use default sorting when query is empty', async () => {
+      prismaMock.article.count.mockResolvedValue(0);
+      prismaMock.article.findMany.mockResolvedValue([]);
+      await getArticles({}, 1);
+
+      expect(prismaMock.article.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+    });
+
+    test('should fallback to default sorting for invalid sort inputs', async () => {
+      prismaMock.article.count.mockResolvedValue(0);
+      prismaMock.article.findMany.mockResolvedValue([]);
+
+      await getArticles({ sort: 'notAField', order: 'wrongOrder' }, 1);
+
+      expect(prismaMock.article.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+    });
+
+    test('should apply valid sorting inputs', async () => {
+      prismaMock.article.count.mockResolvedValue(0);
+      prismaMock.article.findMany.mockResolvedValue([]);
+
+      await getArticles({ sort: 'updatedAt', order: 'asc' }, 1);
+
+      expect(prismaMock.article.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { updatedAt: 'asc' },
+        }),
+      );
+    });
+
   describe('deleteComment', () => {
     test('should throw an error ', () => {
       // Given


### PR DESCRIPTION
Hi Team, I have refactored the article sorting logic into a reusable helper to improve code maintainability and added fallback protection for invalid inputs. Please review.